### PR TITLE
Fix yaml syntax to proper redirect regex with /

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -175,9 +175,9 @@ class FoxgloveStudioCharm(CharmBase):
         middlewares = {
             f"juju-sidecar-trailing-slash-handler-{self.model.name}-{self.model.app.name}": {
                 "redirectRegex": {
-                    "regex": [f"^(.*)\\/{external_path}$"],
-                    "replacement": [f"/{external_path}/"],
-                    "permanent": True,
+                    "regex": f"^(.*)\\/{external_path}$",
+                    "replacement": f"/{external_path}/",
+                    "permanent": False,
                 }
             },
             f"juju-sidecar-noprefix-{self.model.name}-{self.model.app.name}": {

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -96,9 +96,9 @@ class TestCharm(unittest.TestCase):
                     },
                     "juju-sidecar-trailing-slash-handler-testmodel-foxglove-studio": {
                         "redirectRegex": {
-                            "permanent": True,
-                            "regex": ["^(.*)\/testmodel-foxglove-studio$"],  # noqa
-                            "replacement": ["/testmodel-foxglove-studio/"],
+                            "permanent": False,
+                            "regex": "^(.*)\/testmodel-foxglove-studio$",  # noqa
+                            "replacement": "/testmodel-foxglove-studio/",
                         }
                     },
                 },


### PR DESCRIPTION
Fix Traefik configuration yaml syntax for redirectRegex, to correctly redirect url to url/