### PR TITLE
ci(release): use secrets: inherit since it doesn't require the on: secret declaration

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,6 +12,4 @@ on:
 jobs:
   release:
     uses: canonical/observability/.github/workflows/charm-release.yaml@v0
-    # secrets: inherit
-    secrets:
-      CHARMHUB_TOKEN: ${{ secrets.CHARMHUB_TOKEN }}
+    secrets: inherit


### PR DESCRIPTION
The current release workflow is not working due to `CHARMHUB_TOKEN` not being passed properly.

The GH doc mentions:
![image](https://github.com/user-attachments/assets/afb71abb-965e-4634-94f1-9808bdb49b7e)
Which would explain why in the current behavior the token is reported empty: https://github.com/ubuntu-robotics/foxglove-k8s-operator/actions/runs/15906552658/job/44913422596