### PR TITLE
fix(ci): reusable workflow cannot use secrets: inherit

### DIFF
--- a/.github/workflows/charm-release.yaml
+++ b/.github/workflows/charm-release.yaml
@@ -1,0 +1,156 @@
+# This workflow was duplicated from https://github.com/canonical/observability/blob/v0/.github/workflows/charm-release.yaml
+# Because the original reusable workflow was in another organization, the secrets cannot use the "inherit" mechanism.
+# Thus, we duplicated this, and replaced the "inheret" by explicitly passing the CHARMHUB_TOKEN secret
+name: Release Charm
+
+on:
+  workflow_call:
+    inputs:
+      charm-path:
+        description: "Path to the charm we want to publish. Defaults to the current working directory."
+        default: '.'
+        required: false
+        type: string
+      release-tag-prefix:
+        description: "Tag prefix to use for the tag of the GitHub release."
+        default: ''
+        required: false
+        type: string
+      artifact:
+        description: "Name of artifact to download before building. Must contain the file artifact.tar.gz."
+        default: ''
+        required: false
+        type: string
+      provider:
+        description: "The provider to choose for either machine or k8s tests ('lxd' or 'microk8s')"
+        default: 'microk8s'
+        required: false
+        type: string
+      ip-range:
+        type: string
+        description: |
+          The IP range in the address pool for the load balancer to use.
+          It can be either a subnet(IP/mask) or a range (<IP1>-<IP2>)
+        required: false
+        default: null
+      build-for-arm:
+        type: boolean
+        default: false
+        required: false
+        description: |
+          Whether or not to also build the charm for arm64. Defaults to false.
+      charmcraft-channel:
+        type: string
+        default: "3.x/candidate"
+        required: false
+        description: |
+          The snap channel from which to install Charmcraft.
+      juju-channel:
+        type: string
+        default: "3.4/stable"
+        required: false
+        description: |
+          The snap channel from which to install Juju.
+    secrets:
+      CHARMHUB_TOKEN:
+        required: true
+
+concurrency:
+  group: release
+  cancel-in-progress: true
+
+jobs:
+  ci-ignore:
+    name: Check against ignorelist
+    runs-on: ubuntu-latest
+    outputs:
+      any_modified: ${{ steps.echo-changes.outputs.any_modified }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }} # To be compatible with PRs from forks
+          fetch-depth: 0
+
+      - name: Determine changed files in the PR
+        id: changed-files
+        uses: tj-actions/changed-files@2f7c5bfce28377bc069a65ba478de0a74aa0ca32 # Version 46.0.1
+        with:
+          files_ignore: |
+            README.md
+            CONTRIBUTING.md
+            INTEGRATING.md
+            CODEOWNERS
+            LICENSE
+            icon.svg
+            .gitignore
+            .github/**
+
+      - name: Echo changed files
+        id: echo-changes
+        run: |
+          echo "Changes made: ${{ steps.changed-files.outputs.any_modified }}"
+          echo "Modified files: ${{ steps.changed-files.outputs.all_modified_files }}"
+          echo "any_modified=${{ steps.changed-files.outputs.any_modified }}" >> $GITHUB_OUTPUT
+  quality-checks:
+    name: Quality Checks
+    needs:
+      - ci-ignore
+    if: needs.ci-ignore.outputs.any_modified == 'true'
+    uses: canonical/observability/.github/workflows/_charm-quality-checks.yaml@v0
+    secrets:
+      CHARMHUB_TOKEN: ${{ secrets.CHARMHUB_TOKEN }}
+    with:
+      charm-path: "${{ inputs.charm-path }}"
+      provider: "${{ inputs.provider }}"
+      ip-range: "${{ inputs.ip-range }}"
+      charmcraft-channel: ${{ inputs.charmcraft-channel }}
+      juju-channel: ${{ inputs.juju-channel }}
+  release-charm:
+    name: Release Charm and Libraries
+    needs:
+      - quality-checks
+    uses: canonical/observability/.github/workflows/_charm-release.yaml@v0
+    secrets:
+      CHARMHUB_TOKEN: ${{ secrets.CHARMHUB_TOKEN }}
+    with:
+      artifact: "${{ inputs.artifact }}"
+      charm-path: "${{ inputs.charm-path }}"
+      release-tag-prefix: "${{ inputs.release-tag-prefix }}"
+      build-for-arm: ${{ inputs.build-for-arm }}
+  release-libs:
+    name: Release any bumped charm library
+    needs:
+      - quality-checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the source
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          path: charm
+
+      - name: Release libraries
+        run: |
+          # Install Charmcraft
+          sudo snap install charmcraft --classic --channel ${{ inputs.charmcraft-channel }}
+          cd $GITHUB_WORKSPACE/charm/${{ inputs.charm-path }}
+          # Get the charm name
+          charm_name=$((yq .name metadata.yaml 2>/dev/null || yq .name charmcraft.yaml) | tr - _)
+          if [[ $charm_name = "" ]]; then echo "Error: can't extract the charm name." && exit 1; fi
+          # For each library belonging to the charm, publish it
+          if [ -d lib/charms/$charm_name ]; then
+            for lib in $(find lib/charms/$charm_name -type f | sed 's|lib/||' | sed 's/.py//' | sed 's|/|.|g'); do
+              result="$(charmcraft publish-lib $lib --format=json)" || true
+              # Filter out the succesfull publish-lib messages: https://github.com/canonical/charmcraft/issues/1981
+              if [[ "$result" == *"sent to the store with version"* ]]; then
+                echo "$result"
+              elif [[ "$result" == *"already updated"* ]]; then
+                echo "$result"
+              else
+                echo "$result" && exit 1
+              fi
+            done
+          fi
+        env:
+          CHARMCRAFT_AUTH: "${{ secrets.CHARMHUB_TOKEN }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,5 +11,6 @@ on:
 
 jobs:
   release:
-    uses: canonical/observability/.github/workflows/charm-release.yaml@v0
-    secrets: inherit
+    uses: ./.github/workflows/charm-release.yaml
+    secrets:
+      CHARMHUB_TOKEN: ${{ secrets.charmhub_token }}

--- a/src/charm.py
+++ b/src/charm.py
@@ -64,6 +64,7 @@ class FoxgloveStudioCharm(CharmBase):
 
         self.container = self.unit.get_container(self.name)
 
+        # comment to trigger ci
         # -- ingress via raw traefik_route
         self.ingress = TraefikRouteRequirer(self, self.model.get_relation("ingress"), "ingress")  # type: ignore
         self.framework.observe(self.on["ingress"].relation_joined, self._configure_ingress)


### PR DESCRIPTION
We had to duplicate and modify the original workflow, since it was using the `secrets: inherit`.

`secrets: inherit` cannot be used in resuable workflows that are triggered from outside organizations.

Here we are in `ubuntu-robotics` and we are using the workflows from `canonical`.