### PR TITLE
fix(promote): pass the CHARMHUB_TOKEN explicitly

### DIFF
--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -17,4 +17,5 @@ jobs:
     uses: canonical/observability/.github/workflows/charm-promote.yaml@main
     with:
       promotion: ${{ github.event.inputs.promotion }}
-    secrets: inherit
+    secrets:
+      CHARMHUB_TOKEN: ${{ secrets.charmhub_token }}


### PR DESCRIPTION
We were also using the `secrets: inherit` here.

Tested: https://github.com/ubuntu-robotics/foxglove-k8s-operator/actions/runs/15967580228/job/45031224740