### PR TITLE
Test/terraform

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -39,6 +39,7 @@ jobs:
         tox -e terraform-validate
 
   terraform-test:
+    needs: terraform-validate
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -13,7 +13,7 @@ jobs:
   terraform-docs:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         ref: ${{ github.event.pull_request.head.ref }}
 
@@ -25,14 +25,33 @@ jobs:
         output-method: inject
         git-push: "true"
 
-  terraform-lint:
+  terraform-validate:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
-      with:
-        ref: ${{ github.event.pull_request.head.ref }}
-    - name: Lint Terraform
-      uses: actionshub/terraform-lint@main
+    - uses: actions/checkout@v6
+    - name: Install dependencies
+      run: |
+        sudo apt update
+        sudo apt install -y tox
+        sudo snap install terraform --classic
+    - name: Validate Terraform
+      run: |
+        tox -e terraform-validate
+
+  terraform-test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - name: Install dependencies
+      run: |
+        sudo apt update
+        sudo apt install -y tox
+        sudo snap install terraform --classic
+        sudo snap install concierge --classic
+        sudo concierge prepare --preset microk8s
+    - name: Test Terraform
+      run: |
+        tox -e terraform-test
 
   pull-request:
     name: PR

--- a/terraform/tests/main.tf
+++ b/terraform/tests/main.tf
@@ -1,0 +1,30 @@
+data "juju_model" "model" {
+  name  = "testing"
+  owner = "admin"
+}
+
+variable "channel" {
+  description = "The channel to use when deploying a charm"
+  type        = string
+  default     = "latest/edge"
+}
+
+terraform {
+  required_providers {
+    juju = {
+      version = "~> 1.0"
+      source  = "juju/juju"
+    }
+  }
+}
+
+provider "juju" {}
+
+module "foxglove_studio_k8s" {
+  app_name   = "foxglove-studio"
+  source     = "./.."
+  channel    = var.channel
+  model_uuid = data.juju_model.model.uuid
+  units      = 1
+}
+

--- a/terraform/tests/main.tftest.hcl
+++ b/terraform/tests/main.tftest.hcl
@@ -1,0 +1,83 @@
+run "basic_deploy" {
+
+  assert {
+    condition     = module.foxglove_studio_k8s.app_name == "foxglove-studio"
+    error_message = "app_name did not match expected default value"
+  }
+
+  # Test requires integration endpoints - check count
+  assert {
+    condition     = length(module.foxglove_studio_k8s.requires) == 4
+    error_message = "Expected 4 required integration endpoints"
+  }
+
+  # Test requires integration endpoints - check specific keys
+  assert {
+    condition     = contains(keys(module.foxglove_studio_k8s.requires), "catalogue")
+    error_message = "requires output is missing 'catalogue' endpoint"
+  }
+
+  assert {
+    condition     = contains(keys(module.foxglove_studio_k8s.requires), "ingress")
+    error_message = "requires output is missing 'ingress' endpoint"
+  }
+
+  assert {
+    condition     = contains(keys(module.foxglove_studio_k8s.requires), "logging")
+    error_message = "requires output is missing 'logging' endpoint"
+  }
+
+  assert {
+    condition     = contains(keys(module.foxglove_studio_k8s.requires), "tracing")
+    error_message = "requires output is missing 'tracing' endpoint"
+  }
+
+  # Test requires integration endpoints - check exact values
+  assert {
+    condition     = module.foxglove_studio_k8s.requires["catalogue"] == "catalogue"
+    error_message = "requires.catalogue endpoint did not match expected value"
+  }
+
+  assert {
+    condition     = module.foxglove_studio_k8s.requires["ingress"] == "ingress"
+    error_message = "requires.ingress endpoint did not match expected value"
+  }
+
+  assert {
+    condition     = module.foxglove_studio_k8s.requires["logging"] == "logging"
+    error_message = "requires.logging endpoint did not match expected value"
+  }
+
+  assert {
+    condition     = module.foxglove_studio_k8s.requires["tracing"] == "tracing"
+    error_message = "requires.tracing endpoint did not match expected value"
+  }
+
+  # Test provides integration endpoints - check count
+  assert {
+    condition     = length(module.foxglove_studio_k8s.provides) == 2
+    error_message = "Expected 2 provided integration endpoints"
+  }
+
+  # Test provides integration endpoints - check specific keys
+  assert {
+    condition     = contains(keys(module.foxglove_studio_k8s.provides), "grafana_dashboard")
+    error_message = "provides output is missing 'grafana_dashboard' endpoint"
+  }
+
+  assert {
+    condition     = contains(keys(module.foxglove_studio_k8s.provides), "probes")
+    error_message = "provides output is missing 'probes' endpoint"
+  }
+
+  # Test provides integration endpoints - check exact values
+  assert {
+    condition     = module.foxglove_studio_k8s.provides["grafana_dashboard"] == "grafana-dashboard"
+    error_message = "provides.grafana_dashboard endpoint did not match expected value"
+  }
+
+  assert {
+    condition     = module.foxglove_studio_k8s.provides["probes"] == "probes"
+    error_message = "provides.probes endpoint did not match expected value"
+  }
+}

--- a/tox.ini
+++ b/tox.ini
@@ -106,3 +106,29 @@ deps =
     pytest-operator
 commands =
     pytest -vv --tb native --log-cli-level=INFO --color=yes -s {posargs} {toxinidir}/tests/integration
+
+[testenv:terraform-format]
+description = Format terraform files
+commands =
+    terraform fmt -recursive
+allowlist_externals =
+    terraform
+
+[testenv:terraform-validate]
+description = Validate terraform files
+changedir = {toxinidir}
+commands =
+    terraform fmt -check -recursive -diff
+    terraform validate
+allowlist_externals =
+    terraform
+
+[testenv:terraform-test]
+description = Test terraform modules
+changedir = {toxinidir}/terraform/tests
+depends = terraform-validate
+commands =
+    terraform init
+    terraform test -verbose
+allowlist_externals =
+    terraform

--- a/tox.ini
+++ b/tox.ini
@@ -116,9 +116,10 @@ allowlist_externals =
 
 [testenv:terraform-validate]
 description = Validate terraform files
-changedir = {toxinidir}
+changedir = {toxinidir}/terraform
 commands =
     terraform fmt -check -recursive -diff
+    terraform init -backend=false
     terraform validate
 allowlist_externals =
     terraform

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,3 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"


### PR DESCRIPTION
This PR integrate [Terraform tests](https://developer.hashicorp.com/terraform/tutorials/configuration-language/test).

The command `terraform test` is supporting files in the format `tftest.hcl` to validate and test terraform modules.


The tests were added to the CI as well as formatting and validation.

The previous reusable workflow (actionshub/terraform-lint) was actually simply checking the format and seems unmaintained. So I removed it.


